### PR TITLE
fix(scripts): correct relative import path in seed_strategy.ts (#7)

### DIFF
--- a/scripts/seed_strategy.ts
+++ b/scripts/seed_strategy.ts
@@ -1,5 +1,5 @@
 
-import db from './src/lib/db/client';
+import db from '../src/lib/db/client';
 
 const STRATEGY = {
   "Stock": {


### PR DESCRIPTION
Fixes #7. `scripts/seed_strategy.ts` imported `./src/lib/db/client`, which resolves to `scripts/src/lib/db/client` (does not exist). The actual location is one level up at `src/lib/db/client`.

One-character path fix: `./src/...` → `../src/...`

## Test plan

- [x] No other imports in `scripts/` reference `./src`
- [x] Path now matches the project layout (`/tmp/sage/src/lib/db/client.ts`)